### PR TITLE
Update editor syntax highlight color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-github-light-theme",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A Github light theme for Insomnia",
   "main": "plugin.js",
   "repository": {

--- a/themes/github-light-theme.js
+++ b/themes/github-light-theme.js
@@ -7,7 +7,7 @@ const primer = getColors(style);
 
 module.exports = {
   name: "github-light-theme",
-  displayName: "Github Light Theme",
+  displayName: "Github Light",
   theme: {
     foreground: {
       default: pick({ light: primer.gray[6] }),
@@ -16,7 +16,7 @@ module.exports = {
       default: pick({ light: primer.white }),
       success: pick({ light: primer.blue[5] }),
       notice: pick({ light: primer.orange[6] }),
-      warning: pick({ light: primer.gray[5] }),
+      warning: pick({ light: primer.orange[7] }),
       danger: pick({ light: primer.red[7] }),
       surprise: pick({ light: primer.red[5] }),
       info: pick({ light: primer.blue[7] }),


### PR DESCRIPTION
Closes: #1 

Update the editor syntax highlight color of variables to be orange instead of grey so it looks different from comment.

![image](https://user-images.githubusercontent.com/15277233/94011320-6011e880-fdd1-11ea-860e-b05c6fa67ebf.png)

Thanks, @develohpanda for letting me know!